### PR TITLE
Refactor refundOrder in order.js to use loop so can handle edge cases

### DIFF
--- a/src/order.js
+++ b/src/order.js
@@ -1,5 +1,5 @@
 const takeOrder = (order, orders) => orders.length < 3 ? orders.push(order) : orders;
-const refundOrder = (orderNumber, orders) => orders.splice(orderNumber - 1, 1);
+const refundOrder = (orderNumber, orders) => orders.forEach((order, i) => order.orderNumber === orderNumber ? orders.splice(i, 1) : order);
 const listItems = orders => {
   let result = '';
   orders.forEach((order, index) => index === orders.length - 1 ? result += order.item : result += order.item + ', ');


### PR DESCRIPTION
### What does this PR do?

- refactors `refundOrder` function to use forEach to loop through given orders
- this lets it handle the case of removing an item, then removing another item and still removing the correct item the second time

### Is this a feature or a fix?

- fix

### What does it fix?

- `refundOrder` would not remove the proper item in its previous iteration as it was checking index purely off of the given order number, which would no longer be correct if an item had already been changed or the order of items changed

### Where should the reviewer start?

`order.js`

### How should this be tested?

- remove multiple items with `refundOrder` and observe correct functionality